### PR TITLE
fix: 修复侧栏分类、标签、统计组件

### DIFF
--- a/templates/modules/widgets/aside/categories.html
+++ b/templates/modules/widgets/aside/categories.html
@@ -2,13 +2,12 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <!-- 目录 -->
 <div class="card-widget card-categories" th:fragment="categories"
-     ${categoryFinder.list(1, categoryQuantity)}>
+     th:with="categories =  ${categoryFinder.list(1, theme.config.sidebar.categoryQuantity)}">
     <div class="item-headline"><i class="iconfont icon-folder-open"></i><span>分类</span></div>
     <div class="aside-list">
         <ul class="card-category-list">
             <li class="card-category-list-item" th:each="category,iterStat : ${categories}">
-                <a class="card-category-list-link" th:href="@{${category.status.permalink}}"
-                   th:if="${categoryQuantity >= 0 && iterStat.index < categoryQuantity ||  categoryQuantity < 0}">
+                <a class="card-category-list-link" th:href="@{${category.status.permalink}}">
                         <span class="card-category-list-name" th:text="${category.spec.displayName}"
                               th:title="${category.spec.displayName}"></span>
                     <span class="card-category-list-count" th:text="${category.status.postCount}"></span>

--- a/templates/modules/widgets/aside/contain/stat-contain.html
+++ b/templates/modules/widgets/aside/contain/stat-contain.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<!-- 侧边栏站点信息统计 -->
+
+<th:block th:fragment="stat-contain" th:with="stats = ${siteStatsFinder.getStats()}">
+
+    <div class="item-headline"><i class="iconfont icon-icon-sidebar-scxmtj"></i><span>统计</span></div>
+    <div class="webinfo">
+        <div class="webinfo-item">
+            <div class="webinfo-item-title"><i class="iconfont icon-file-alt"></i>
+                <div class="item-name">文章数 :</div>
+            </div>
+            <div class="item-count" th:text="${stats.post}"></div>
+        </div>
+        <!--<div class="webinfo-item">-->
+        <!--    <div class="webinfo-item-title"><i class="item-icon fas fa-stopwatch"></i>-->
+        <!--        <div class="item-name">建站天数 :</div>-->
+        <!--    </div>-->
+        <!--    <div class="item-count" data-publishdate="2019-10-27T16:00:00.000Z" id="runtimeshow"></div>-->
+        <!--</div>-->
+        <!--<div class="webinfo-item">-->
+        <!--    <div class="webinfo-item-title"><i class="item-icon fas fa-font"></i>-->
+        <!--        <div class="item-name">全站字数 :</div>-->
+        <!--    </div>-->
+        <!--    <div class="item-count">606.7k</div>-->
+        <!--</div>-->
+        <div class="webinfo-item">
+            <div class="webinfo-item-title"><i class="iconfont icon-sliders"></i>
+                <div class="item-name">分类数 :</div>
+            </div>
+            <div class="item-count" th:text="${stats.category}"></div>
+        </div>
+        <div class="webinfo-item">
+            <div class="webinfo-item-title"><i class="iconfont icon-comment-alt"></i>
+                <div class="item-name">评论数 :</div>
+            </div>
+            <div class="item-count" th:text="${stats.comment}"></div>
+        </div>
+        <div class="webinfo-item">
+            <div class="webinfo-item-title"><i class="iconfont icon-bullseye"></i>
+                <div class="item-name">访问量 :</div>
+            </div>
+            <div class="item-count" th:text="${stats.visit}"></div>
+        </div>
+    </div>
+</th:block>
+
+</html>

--- a/templates/modules/widgets/aside/contain/tags-contain.html
+++ b/templates/modules/widgets/aside/contain/tags-contain.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<!-- 标签 -->
+
+<th:block th:fragment="tags-contain"
+          th:with="tags = ${tagFinder.listAll()}, tagQuantity = ${#conversions.convert(theme.config.sidebar.tagQuantity, 'java.lang.Integer')}">
+
+    <div class="item-headline"><i class="iconfont icon-tags"></i><span>标签</span></div>
+    <div class="card-tag-cloud">
+        <a style="font-size:1em;color:#d3d3d3" th:each="tag,iterStat : ${tags}"
+           th:href="@{${tag.status.permalink}}"
+           th:if="${tagQuantity >= 0 && iterStat.index < tagQuantity || tagQuantity < 0}"
+           th:title="${tag.spec.displayName}">
+            <!-- 角标 -->
+            [[${tag.spec.displayName}]]<sup th:text="${tag.status.postCount}"></sup>
+        </a>
+
+    </div>
+
+</th:block>
+
+
+</html>

--- a/templates/modules/widgets/aside/stat.html
+++ b/templates/modules/widgets/aside/stat.html
@@ -1,48 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-<!-- 侧边栏站点信息统计 -->
 
-<th:block th:fragment="stat" th:with="stats = ${siteStatsFinder.getStats()}">
 
-    <div class="item-headline"><i class="iconfont icon-icon-sidebar-scxmtj"></i><span>统计</span></div>
-    <div class="webinfo">
-        <div class="webinfo-item">
-            <div class="webinfo-item-title"><i class="iconfont icon-file-alt"></i>
-                <div class="item-name">文章数 :</div>
-            </div>
-            <div class="item-count" th:text="${stats.post}"></div>
-        </div>
-        <!--<div class="webinfo-item">-->
-        <!--    <div class="webinfo-item-title"><i class="item-icon fas fa-stopwatch"></i>-->
-        <!--        <div class="item-name">建站天数 :</div>-->
-        <!--    </div>-->
-        <!--    <div class="item-count" data-publishdate="2019-10-27T16:00:00.000Z" id="runtimeshow"></div>-->
-        <!--</div>-->
-        <!--<div class="webinfo-item">-->
-        <!--    <div class="webinfo-item-title"><i class="item-icon fas fa-font"></i>-->
-        <!--        <div class="item-name">全站字数 :</div>-->
-        <!--    </div>-->
-        <!--    <div class="item-count">606.7k</div>-->
-        <!--</div>-->
-        <div class="webinfo-item">
-            <div class="webinfo-item-title"><i class="iconfont icon-sliders"></i>
-                <div class="item-name">分类数 :</div>
-            </div>
-            <div class="item-count" th:text="${stats.category}"></div>
-        </div>
-        <div class="webinfo-item">
-            <div class="webinfo-item-title"><i class="iconfont icon-comment-alt"></i>
-                <div class="item-name">评论数 :</div>
-            </div>
-            <div class="item-count" th:text="${stats.comment}"></div>
-        </div>
-        <div class="webinfo-item">
-            <div class="webinfo-item-title"><i class="iconfont icon-bullseye"></i>
-                <div class="item-name">访问量 :</div>
-            </div>
-            <div class="item-count" th:text="${stats.visit}"></div>
-        </div>
-    </div>
-</th:block>
-
-</html>
+<div class="card-widget card-webinfo"  th:fragment="stat">
+    <th:block th:replace="modules/widgets/aside/contain/stat-contain :: stat-contain"></th:block>
+</div>

--- a/templates/modules/widgets/aside/tags-stat.html
+++ b/templates/modules/widgets/aside/tags-stat.html
@@ -6,11 +6,11 @@
 
     <div class="card-widget card-tags card-archives card-webinfo card-allinfo">
 
-        <th:block th:replace="modules/widgets/aside/tags :: tags"></th:block>
+        <th:block th:replace="modules/widgets/aside/contain/tags-contain :: tags-contain"></th:block>
 
         <hr>
 
-        <th:block th:replace="modules/widgets/aside/stat :: stat"></th:block>
+        <th:block th:replace="modules/widgets/aside/contain/stat-contain :: stat-contain"></th:block>
 
     </div>
 

--- a/templates/modules/widgets/aside/tags-stat.html
+++ b/templates/modules/widgets/aside/tags-stat.html
@@ -4,16 +4,14 @@
 
 <th:block th:fragment="tags-stat">
 
-    <div class="sticky_layout">
-        <div class="card-widget card-tags card-archives card-webinfo card-allinfo">
+    <div class="card-widget card-tags card-archives card-webinfo card-allinfo">
 
-            <th:block th:replace="modules/widgets/aside/tags :: tags"></th:block>
+        <th:block th:replace="modules/widgets/aside/tags :: tags"></th:block>
 
-            <hr>
+        <hr>
 
-            <th:block th:replace="modules/widgets/aside/stat :: stat"></th:block>
+        <th:block th:replace="modules/widgets/aside/stat :: stat"></th:block>
 
-        </div>
     </div>
 
 </th:block>

--- a/templates/modules/widgets/aside/tags.html
+++ b/templates/modules/widgets/aside/tags.html
@@ -2,22 +2,6 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <!-- 标签 -->
 
-<th:block th:fragment="tags"
-          th:with="tags = ${tagFinder.listAll()}, tagQuantity = ${#conversions.convert(theme.config.sidebar.tagQuantity, 'java.lang.Integer')}">
-
-    <div class="item-headline"><i class="iconfont icon-tags"></i><span>标签</span></div>
-    <div class="card-tag-cloud">
-        <a style="font-size:1em;color:#d3d3d3" th:each="tag,iterStat : ${tags}"
-           th:href="@{${tag.status.permalink}}"
-           th:if="${tagQuantity >= 0 && iterStat.index < tagQuantity ||  categoryQuantity < 0}"
-           th:title="${tag.spec.displayName}">
-            <!-- 角标 -->
-            [[${tag.spec.displayName}]]<sup th:text="${tag.status.postCount}"></sup>
-        </a>
-
-    </div>
-
-</th:block>
-
-
-</html>
+<div class="card-widget card-tags"  th:fragment="tags">
+    <th:block th:replace="modules/widgets/aside/contain/tags-contain :: tags-contain"></th:block>
+</div>


### PR DESCRIPTION
1. 参照 https://github.com/liuzhihang/halo-theme-hao/issues/56#issuecomment-1385124636 方法
当使用`categoryFinder.list(page,size)`分页查询后无需对便利的item进行判断

2. fix: 移除不必要的div 会导致div重复
![image](https://user-images.githubusercontent.com/50261327/215992134-442459cd-5546-4aac-8294-0f68049ad9ba.png)


3. fix: tags和stat组件没有card样式的问题
![1c8fef58ab0829a3c32376f2abdb087](https://user-images.githubusercontent.com/50261327/215992914-40c1f010-3f93-4cf9-bd0c-c226bcca4b4b.png)
![image](https://user-images.githubusercontent.com/50261327/215993077-74da90f6-8ba6-4592-9f83-ebb02497e80c.png)
