### PR TITLE
页脚默认设置相关优化

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,16 @@
 
 ## 🔥 预览
 
-|   站点名称   |           站点地址            |
-|:--------:|:-------------------------:|
-|  程序员小航   |  https://liuzhihang.com   |
-|    流殃    |   https://shyblog.world   |
-|    羡羡    |  https://www.hydsb0.com/  |
-|   困困鱼    |     https://kunkunyu.com      |
-| Top John |    https://op-lab.top     |
-|  Roozen  |    https://roozen.top     |
-|  Lanbin  |    https://lib.lanbin.top |
+|    站点名称    |          站点地址           |
+|:----------:|:-----------------------:|
+|   程序员小航    | https://liuzhihang.com  |
+|     流殃     |  https://shyblog.world  |
+|     羡羡     | https://www.hydsb0.com/ |
+|    困困鱼     |  https://kunkunyu.com   |
+|  Top John  |   https://op-lab.top    |
+|   Roozen   |   https://roozen.top    |
+|   Lanbin   | https://lib.lanbin.top  |
+| Carol`s 小屋 | https://blog.cnkj.site  |
 
 ## 👋 简介
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "halo-theme-hao",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "dependencies": {
   }
 }

--- a/settings.yaml
+++ b/settings.yaml
@@ -1041,7 +1041,36 @@ spec:
           children:
             - $formkit: radio
               name: default_enable
+              id: default_enable
+              key: default_enable
               label: 底部
+              options:
+                - label: 显示
+                  value: true
+                - label: 隐藏
+                  value: false
+            - $formkit: radio
+              if: $get(default_enable).value
+              name: dingyue
+              label: 订阅
+              options:
+                - label: 显示
+                  value: true
+                - label: 隐藏
+                  value: false
+            - $formkit: radio
+              if: $get(default_enable).value
+              name: zhuti
+              label: 主题
+              options:
+                - label: 显示
+                  value: true
+                - label: 隐藏
+                  value: false
+            - $formkit: radio
+              if: $get(default_enable).value
+              name: about
+              label: 关于
               options:
                 - label: 显示
                   value: true

--- a/templates/modules/footer.html
+++ b/templates/modules/footer.html
@@ -119,19 +119,25 @@
             </div>
             <div class="footer-banner-right">
                 <!-- 订阅 需要 RSS 插件支持 -->
-                <a class="footer-banner-link" href="/sitemap.xml"
-                   th:if="${pluginFinder.available('PluginSitemap')}">订阅</a>
-                <a class="footer-banner-link" href="https://github.com/liuzhihang/halo-theme-hao">主题</a>
-                <a class="footer-banner-link" href="/about">关于</a>
+                <a class="footer-banner-link" href="/rss.xml" th:if="${pluginFinder.available('PluginFeed')} and ${theme.config.footer.footerContent.dingyue}">订阅</a>
+                <a th:if="${theme.config.footer.footerContent.zhuti}" class="footer-banner-link" href="https://github.com/liuzhihang/halo-theme-hao">主题</a>
+                <a th:if="${theme.config.footer.footerContent.about}" class="footer-banner-link" href="/about">关于</a>
                 <a th:if="${not #strings.isEmpty(theme.config.basics.icp)}"
                    class="footer-banner-link" href="https://beian.miit.gov.cn/#/Integrated/index"
                    rel="noopener external nofollow noreferrer noopener"
-                   target="_blank">[[${theme.config.basics.icp}]]
+                   target="_blank">
+                    <span th:if="${not #strings.startsWith(theme.config.basics.icp, 'http')}">[[${theme.config.basics
+                        .icp}]]</span>
+                    <img th:if="${#strings.startsWith(theme.config.basics.icp, 'http')}"
+                         th:src="@{${theme.config.basics.icp}}" alt="icp"/>
                 </a>
                 <a th:if="${not #strings.isEmpty(theme.config.basics.gongan)}"
                    class="footer-banner-link" href="http://www.beian.gov.cn/portal/registerSystemInfo"
                    rel="noopener external nofollow noreferrer noopener"
-                   target="_blank">[[${theme.config.basics.gongan}]]
+                   target="_blank">
+                    <span th:if="${not #strings.startsWith(theme.config.basics.gongan, 'http')}">[[${theme.config.basics.gongan}]]</span>
+                    <img th:if="${#strings.startsWith(theme.config.basics.gongan, 'http')}"
+                         th:src="@{${theme.config.basics.gongan}}" alt="gongan"/>
                 </a>
                 <a class="footer-banner-link cc" th:href="${theme.config.basics.copyrightAgreement}"
                    th:if="${not #strings.isEmpty(theme.config.basics.copyrightAgreement)}" title="cc协议">

--- a/theme.yaml
+++ b/theme.yaml
@@ -51,5 +51,5 @@ spec:
   repo: https://githubfast.com/liuzhihang/halo-theme-hao
   settingName: "theme-hao-setting"
   configMapName: "theme-hao-configMap"
-  version: "1.4.3"
+  version: "1.4.4"
   require: ">=2.10.0"


### PR DESCRIPTION
[@](https://github.com/liuzhihang/halo-theme-hao/issues/565)
* add: 新增页脚默认设置对订阅、主题、关于等按钮的控制
* add: 新增基础设置中对ICP和公网安的配置，使用http地址可自动识别为图片链接
* fix: 修复页脚默认设置中订阅按钮跳转地址错误问题