### PR TITLE
完全修复：侧边栏内容设置项中，去除 文章页 和 首页 配置中的profile项会导致界面显示异常

### DIFF
--- a/templates/assets/zhheo/zhheoblog.css
+++ b/templates/assets/zhheo/zhheoblog.css
@@ -2218,6 +2218,10 @@ blockquote footer cite::before {
     margin-top: 1rem;
 }
 
+#aside-content :only-child > :first-child {
+    margin-top: 0rem;
+}
+
 #aside-content .card-more-btn {
     float: right;
     color: inherit;
@@ -6803,19 +6807,26 @@ body[data-type=music] .page #nav #site-name span{
     }
 }
 
+/* 保证无card-widget时自动和左侧元素对齐 */
 @media screen and (min-width: 1300px) {
     #aside-content .sticky_layout {
-        margin-top: 1rem;
+        margin-top: 0rem;
+    }
+}
+
+/* 用 :has() 伪类判断card-widget是否存在，进行属性覆写 */
+/* 若存在，表明需要和card-widget保持距离 */
+@media screen and (min-width: 1300px) {
+    #aside-content:has(+.card-widget) {
+        #aside-content .sticky_layout {
+            margin-top: 1rem;
+        }
     }
 }
 
 #aside-content .sticky_layout {
     top: 80px;
     transition: top 0s;
-}
-
-#aside-content .sticky_layout .card-widget:first-child {
-    margin-top: 0;
 }
 
 #aside-content .card-widget:hover {
@@ -9890,8 +9901,13 @@ div#author-info__sayhi:hover {
     transform: scale(1.1)
 }
 
-/* 作者卡片背景 */
+/* 选中第一个卡片，与左侧元素对齐 */
 #aside-content > .card-widget:first-child {
+    margin-top: 0px;
+}
+
+/* 作者卡片背景 */
+#aside-content > .card-widget.card-info {
     transition: 0.3s;
     border: none;
     box-shadow: none;


### PR DESCRIPTION
+ fix #611 完全修复

即修复：
> 1. 首页 侧边栏第一个卡片拥有了profile的底色属性。
> 2. 文章页 侧边栏卡片间距为0，挤在一起。

---
测试结果：
+ 加入profile项
![图片](https://github.com/liuzhihang/halo-theme-hao/assets/36284614/138cb7bc-887f-428e-9c26-2c0dd82745fd)

|首页|文章页|
|-|-|
|![图片](https://github.com/liuzhihang/halo-theme-hao/assets/36284614/666ba9c6-58ab-4565-9150-75ad3b6e070b)|![图片](https://github.com/liuzhihang/halo-theme-hao/assets/36284614/c5e5321c-8a83-4df3-8116-f007a17f77d3)|

+ 去除profile项
![图片](https://github.com/liuzhihang/halo-theme-hao/assets/36284614/73b9ccfd-7d6b-492c-87c9-0a9f2e23a84e)

|首页|文章页|
|-|-|
|![图片](https://github.com/liuzhihang/halo-theme-hao/assets/36284614/f0f73326-874d-4f82-b5a0-20fa4c2460a4)|![图片](https://github.com/liuzhihang/halo-theme-hao/assets/36284614/b0047978-0736-466e-9dbd-76381ebfa74c)|

界面完全正常