### PR TITLE
feat(post.html): 添加最后更新时间显示

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -1416,6 +1416,15 @@ spec:
               label: 温馨提示文案
               help: "自定义温馨提示的文案，支持html语法"
               language: html
+        - $formkit: radio
+          name: update_time
+          label: 最后更新时间
+          value: false
+          options:
+            - label: 打开
+              value: true
+            - label: 关闭
+              value: false
         - $formkit: select
           name: copyrightsStyle
           id: copyrightsStyle

--- a/templates/post.html
+++ b/templates/post.html
@@ -78,7 +78,7 @@
                                   th:title="${#dates.format(post.spec.publishTime,'yyyy-MM-dd HH:mm:ss')}">
                             </time>
                         </span>
-                        <span class="post-meta-date">
+                        <span class="post-meta-date" th:if="${theme.config.post.update_time}">
                             <i class="haofont hao-icon-pencil post-meta-icon" title="最后更新时间"></i>
                             <time th:attr="datetime=${#dates.format(post.status.lastModifyTime, 'yyyy-MM-dd')}"
                                   th:text="${#dates.format(post.status.lastModifyTime,'yyyy/MM/dd')}"

--- a/templates/post.html
+++ b/templates/post.html
@@ -78,6 +78,13 @@
                                   th:title="${#dates.format(post.spec.publishTime,'yyyy-MM-dd HH:mm:ss')}">
                             </time>
                         </span>
+                        <span class="post-meta-date">
+                            <i class="haofont hao-icon-pencil post-meta-icon" title="最后更新时间"></i>
+                            <time th:attr="datetime=${#dates.format(post.status.lastModifyTime, 'yyyy-MM-dd')}"
+                                  th:text="${#dates.format(post.status.lastModifyTime,'yyyy/MM/dd')}"
+                                  th:title="${#dates.format(post.status.lastModifyTime,'yyyy-MM-dd HH:mm:ss')}">
+                            </time>
+                        </span>
                         <span th:with="syncStatus=${#strings.isEmpty(#annotations.get(post, 'sync_status')) ? '未同步': #annotations.get(post, 'sync_status')}"
                               class="post-meta-wechat" th:title=" ${pluginFinder.available('plugin-platforms-sync') &&  (syncStatus == '同步更新文章成功' || syncStatus == '同步上传文章成功') ? '该文章已在公众号中更新' : '该文章在博客首发'}">
                             <th:block th:unless="${pluginFinder.available('plugin-platforms-sync') && (syncStatus == '同步更新文章成功' || syncStatus == '同步上传文章成功')}">


### PR DESCRIPTION
在文章页面发布时间后边添加最后更新时间显示,为了结合设置中过期文章提醒相互印证。
![image](https://github.com/liuzhihang/halo-theme-hao/assets/20491834/125463f4-d52f-4dcc-9634-00bc97dc9cfd)
