### PR TITLE
feat：添加萌国ICP备案相关设置

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -30,6 +30,11 @@ spec:
           label: 公安备案
           placeholder: 请输入公安备案号
           help: 格式：皖公网安备 xxxxxxxx 号
+        - $formkit: text
+          name: moeicp
+          label: 萌国ICP
+          placeholder: 请输入萌国ICP号
+          help: 格式：萌ICP备xxxxxxxx号
         - $formkit: url
           name: copyrightAgreement
           label: 版权协议
@@ -1363,6 +1368,7 @@ spec:
               about: true
               icp_icon: true
               gongwangan: true
+              moeicp: true
               yingsi: true
               yunzhichi: false
               footer_banner_padding: 1
@@ -1425,6 +1431,12 @@ spec:
                   id: gongwangan
                   key: gongwangan
                   label: 公网安备案
+                - $formkit: switch
+                  if: $get(default_enable).value
+                  name: moeicp
+                  id: moeicp
+                  key: moeicp
+                  label: 萌国ICP备案
                 - $formkit: switch
                   if: $get(default_enable).value
                   name: yingsi

--- a/templates/modules/footer.html
+++ b/templates/modules/footer.html
@@ -186,6 +186,14 @@
                     <img th:if="${#strings.startsWith(theme.config.basics.gongan, 'http')}"
                          th:src="@{${theme.config.basics.gongan}}" alt="gongan"/>
                 </a>
+                <th:block th:if="${not #strings.isEmpty(theme.config.basics.moeicp) && theme.config.footer.footerContent.default_enable_group.moeicp}">
+                    <a th:with="moeicpKeyword=${theme.config.basics.moeicp.replaceAll('[^0-9]', '')}"
+                        class="footer-banner-link" th:href="|https://icp.gov.moe/?keyword=${moeicpKeyword}|"
+                        rel="noopener external nofollow noreferrer noopener"
+                        target="_blank">
+                        <span th:if="${not #strings.startsWith(theme.config.basics.moeicp, 'http')}">[[${theme.config.basics.moeicp}]]</span>
+                    </a>
+                </th:block>
                 <a class="footer-banner-link cc" th:href="${theme.config.basics.copyrightAgreement}"
                    th:if="${not #strings.isEmpty(theme.config.basics.copyrightAgreement) && theme.config.footer.footerContent.default_enable_group.yingsi}" title="cc协议">
                     <i class="haofont hao-icon-copyright-line"></i>


### PR DESCRIPTION
页脚处添加了萌国ICP备案的显示，基础设置中添加备案号信息设置，页脚设置中添加萌国ICP备案开关：
<img width="2528" height="307" alt="image" src="https://github.com/user-attachments/assets/eb99c6a3-2fca-42fb-ad26-52bb8d6cd579" />
<img width="959" height="610" alt="image" src="https://github.com/user-attachments/assets/504c0e74-b12e-46e0-8a77-a08cf5b16973" />
<img width="866" height="591" alt="image" src="https://github.com/user-attachments/assets/41a9a071-342d-40f4-9f4c-b99fa51096ad" />
